### PR TITLE
fixed error handling and added ssl certificate

### DIFF
--- a/sq-zabbix.py
+++ b/sq-zabbix.py
@@ -7,7 +7,16 @@
 import sys
 import os
 import json
+import ssl
 import urllib.request
+import logging
+
+logger = logging.getLogger('sq-zabbix.py')
+hdlr = logging.FileHandler('/tmp/sq-zabbix-py.log')
+formatter = logging.Formatter('%(asctime)s %(levelname)s %(message)s')
+hdlr.setFormatter(formatter)
+logger.addHandler(hdlr)
+logger.setLevel(logging.WARNING)
 
 def print_usage():
     """Print the script usage"""
@@ -27,14 +36,15 @@ def form_payload(data = "", subject = ""):
 def post_to_url(url, payload):
     """Posts the formed payload as json to the passed url"""
     try:
+        gcontext = ssl.SSLContext()
         req = urllib.request.Request(url, data=bytes(json.dumps(payload), "utf-8"))
         req.add_header("Content-Type", "application/json")
-        resp = urllib.request.urlopen(req)
+        resp = urllib.request.urlopen(req,context=gcontext)
         if resp.status > 299:
-           print("[sq-zabbix] Request failed with status code %s : %s" % (resp.status, resp.read()))
-    except urllib.request.URLError as e:
+           logger.error("[sq-zabbix] Request failed with status code %s : %s" % (resp.status, resp.read()))
+    except urllib.request.HTTPError as e:
         if e.code >= 400 and e.code < 500:
-            print("[sq-zabbix] Some error occured while processing the event")
+            logger.error("[sq-zabbix] Some error occured while processing the event")
 
 if __name__ == "__main__":
     if len(sys.argv) != 4:
@@ -43,6 +53,10 @@ if __name__ == "__main__":
     url = sys.argv[1]
     subject = sys.argv[2]
     data = sys.argv[3]
+    logger.error("[sq-zabbix] url:{}".format(url))
+    logger.error("[sq-zabbix] subject:{}".format(subject))
+    logger.error("[sq-zabbix] data:{}".format(data))
     print("Sending data to squadcast")
+    print(form_payload(data, subject))
     post_to_url(url, form_payload(data, subject))
     print("Done.")


### PR DESCRIPTION
- Apparently urllib has updated I think and now, URLError doesn't have any `code` attribute, HTTPError has it. Fixed it.
- Another bug: urllib was complaining `SSL: CERTIFICATE_VERIFY_FAILED` when calling `urlopen()`. Included a `SSLContext` to prevent that(Refer: https://stackoverflow.com/a/28052583/6528908).
- Print statement will be useless when Zabbix will execute the file. Added log files.